### PR TITLE
remove Arduino word in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Arduino Fast ST7735 Library
+name=Fast ST7735 Library
 version=1.0.1
 author=Pawel A. Hernik
 maintainer=Pawel A. Hernik <pawelhernik123@gmail.com>


### PR DESCRIPTION
Remove "_Arduino_" in the name field of the `library.properties` to be compliant with Library Manager FAQ
https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ