### PR TITLE
Added optional colourmode to constructor, allows switching between RGB and BGR

### DIFF
--- a/Arduino_ST7735_Fast.cpp
+++ b/Arduino_ST7735_Fast.cpp
@@ -43,7 +43,7 @@ Rcmd1[] = {                       // 7735R init, part 1 (red or green tab)
   0x0E,
   ST7735_INVOFF,  0,              // 13: Don't invert display, no args
   ST7735_MADCTL,  1,              // 14: Mem access ctl (directions), 1 arg:
-  0xC8,                         //     row/col addr, bottom-top refresh
+  (ST7735_MADCTL_MX | ST7735_MADCTL_MY | ST7735_MADCTL_BGR),                         //     row/col addr, bottom-top refresh
   ST7735_COLMOD,  1,              // 15: set color mode, 1 arg, no delay:
   0x05 },
       
@@ -124,11 +124,16 @@ inline void Arduino_ST7735::writeSPI(uint8_t c)
 }
 
 // ----------------------------------------------------------
-Arduino_ST7735::Arduino_ST7735(int8_t dc, int8_t rst, int8_t cs) : Adafruit_GFX(ST7735_TFTWIDTH, ST7735_TFTHEIGHT) 
+Arduino_ST7735::Arduino_ST7735(int8_t dc, int8_t rst, int8_t cs, int8_t colourMode) : Adafruit_GFX(ST7735_TFTWIDTH, ST7735_TFTHEIGHT) 
 {
   csPin = cs;
   dcPin = dc;
   rstPin = rst;
+  if(colourMode == ST7735_MADCTL_RGB || colourMode == ST7735_MADCTL_BGR){
+    _colourMode = colourMode;
+  }else{
+    _colourMode = ST7735_MADCTL_RGB;
+  }
 }
 
 // ----------------------------------------------------------
@@ -232,28 +237,28 @@ void Arduino_ST7735::setRotation(uint8_t m)
   rotation = m & 3;
   switch (rotation) {
    case 0:
-     writeData(ST7735_MADCTL_MX | ST7735_MADCTL_MY | ST7735_MADCTL_RGB);
+     writeData(ST7735_MADCTL_MX | ST7735_MADCTL_MY | _colourMode);
      _xstart = _colstart;
      _ystart = _rowstart;
      _height = ST7735_TFTHEIGHT;
      _width  = ST7735_TFTWIDTH;
      break;
    case 1:
-     writeData(ST7735_MADCTL_MY | ST7735_MADCTL_MV | ST7735_MADCTL_RGB);
+     writeData(ST7735_MADCTL_MY | ST7735_MADCTL_MV | _colourMode);
      _ystart = _colstart;
      _xstart = _rowstart;
      _width  = ST7735_TFTHEIGHT;
      _height = ST7735_TFTWIDTH;
      break;
   case 2:
-     writeData(ST7735_MADCTL_RGB);
+     writeData(_colourMode);
      _xstart = _colstart;
      _ystart = _rowstart;
      _height = ST7735_TFTHEIGHT;
      _width  = ST7735_TFTWIDTH;
      break;
    case 3:
-     writeData(ST7735_MADCTL_MX | ST7735_MADCTL_MV | ST7735_MADCTL_RGB);
+     writeData(ST7735_MADCTL_MX | ST7735_MADCTL_MV | _colourMode);
      _ystart = _colstart;
      _xstart = _rowstart;
      _width  = ST7735_TFTHEIGHT;

--- a/Arduino_ST7735_Fast.h
+++ b/Arduino_ST7735_Fast.h
@@ -34,7 +34,6 @@
 #define ST7735_TFTHEIGHT 	160
 
 // Some register settings
-#define ST7735_MADCTL_BGR 0x08
 #define ST7735_MADCTL_MH  0x04
 
 #define ST7735_FRMCTR1    0xB1
@@ -99,7 +98,7 @@
 #define ST7735_MADCTL_MV  0x20
 #define ST7735_MADCTL_ML  0x10
 #define ST7735_MADCTL_RGB 0x00
-
+#define ST7735_MADCTL_BGR 0x08
 
 // Color definitions
 #define	BLACK   0x0000
@@ -116,8 +115,7 @@
 class Arduino_ST7735 : public Adafruit_GFX {
 
  public:
-  Arduino_ST7735(int8_t DC, int8_t RST, int8_t CS = -1);
-
+  Arduino_ST7735(int8_t DC, int8_t RST, int8_t CS = -1, int8_t colourMode = 0);
   void init();
   void begin() { init(); }
   void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
@@ -158,7 +156,7 @@ class Arduino_ST7735 : public Adafruit_GFX {
   void writeData(uint8_t d);
 
  private:
-  int8_t  csPin, dcPin, rstPin;
+  int8_t  csPin, dcPin, rstPin, _colourMode;
   uint8_t  csMask, dcMask;
   volatile uint8_t  *csPort, *dcPort;
 


### PR DESCRIPTION
- Added colourmode variable to constructor
- Default functionality is unchanged
- Fully compatible
- To change from default RGB mode to BGR mode `Arduino_ST7735 lcd = Arduino_ST7735(TFT_DC, TFT_RST, TFT_CS, ST7735_MADCTL_BGR);`

Note: Clarified the bit combinations to `Rcmd1` and found that interestingly it sets the colour to BGR first and then `setRotation` corrects the colour setting. This makes correct initialisation dependant on the call to `setRotation` on line 183 of `Arduino_ST7735_Fast.cpp`